### PR TITLE
Fix permission issues with grafana and prometheus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore IntelliJ IDEA project files
 .idea/
+grafana/data/
+prometheus/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: monitoring-grafana
     hostname: rpi-grafana
     restart: unless-stopped
-    user: "472"
+    user: $(id -u):$(id -g) # Dynamic user mapping
     networks:
       - internal
     ports:
@@ -65,7 +65,7 @@ services:
     container_name: monitoring-prometheus
     hostname: rpi-prometheus
     restart: unless-stopped
-    user: "nobody"
+    user: "65534:65534" # Explicit user and group ID
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'


### PR DESCRIPTION
Fix permission issues in grafana and prometheus docker services.

If that does not work try running these commands:

```bash
# Set grafana permissions
sudo chown -R 472:472 ./grafana/data ./grafana/provisioning

# Set prometheus permissions
sudo chown -R 65534:65534 ./prometheus/data ./prometheus
```